### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validate-slides.yml
+++ b/.github/workflows/pr-validate-slides.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "slides/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-slides-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/MSBart2/CopilotTraining/security/code-scanning/8](https://github.com/MSBart2/CopilotTraining/security/code-scanning/8)

In general, the fix is to add an explicit `permissions:` block that grants only the scopes this workflow needs, ideally at the workflow root so it applies to all jobs. For this workflow, the steps only require reading repository contents (for `actions/checkout`) and do not need to push commits, create tags, manage issues, or modify pull requests, so `contents: read` is sufficient as a minimal starting point.

The single best fix here is:

- Add a `permissions:` block near the top of `.github/workflows/pr-validate-slides.yml`, at the workflow level (same indentation as `on:` and `jobs:`), setting `contents: read`.
- This will apply to the `validate` job automatically since it does not define its own `permissions:` block.
- No other logic or steps need to change, and no additional imports or methods are required because this is pure YAML configuration.

Concretely, insert:

```yml
permissions:
  contents: read
```

after the `on:` block (lines 3–7) and before `concurrency:` (line 8), keeping indentation consistent.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
